### PR TITLE
Fixed a typo in docstring

### DIFF
--- a/calculate_scalars.py
+++ b/calculate_scalars.py
@@ -54,7 +54,7 @@ def calculate_scalars():
 def combine_assessed_cmip(scalar):
     '''
     Convert CMIP6 multimodel mean timeseries into anomalies relative to 1850-1899. Use a LOESS smoother
-    to remove short-term variability in the CMIP6 MMM series. Normalize AR6 assessed and smooted CMIP6 GSAT 
+    to remove short-term variability in the CMIP6 MMM series. Normalize AR6 assessed and smoothed CMIP6 GSAT 
     to 2015 when AR6 assessed warming projections begin. Calculate a scalar based on the ratio of the two.
     '''
     scalar.sort_values(by=['Year'], inplace=True)


### PR DESCRIPTION
I've just fixed a typo in the `combine_assessed_cmip` docstring. 

Thank you very much for making this material publicly available! 